### PR TITLE
Implement int and double support for .has

### DIFF
--- a/Icris.GremlinQuery/Icris.GremlinQuery.Tests/QueryTestSet.cs
+++ b/Icris.GremlinQuery/Icris.GremlinQuery.Tests/QueryTestSet.cs
@@ -59,7 +59,17 @@ namespace Icris.GremlinQuery.Tests
                 "g.V().has('status',false)",
                 g.V().has("status", false).ToString()
             );
-            //Add boolean property
+            //Test Integer
+            Assert.AreEqual(
+                "g.V().has('status',1)",
+                g.V().has("status", (int)1).ToString()
+            );
+            //Test Double
+            Assert.AreEqual(
+                "g.V().has('status',1.5223)",
+                g.V().has("status", (double)1.5223).ToString()
+            );
+            //test boolean property
             Assert.AreEqual(
                 "g.V().property('status',true)",
                 g.V().property("status", true).ToString()
@@ -67,6 +77,15 @@ namespace Icris.GremlinQuery.Tests
             Assert.AreEqual(
                 "g.V().property('status',false)",
                 g.V().property("status", false).ToString()
+            );
+            //Test interger property
+            Assert.AreEqual(
+                "g.V().property('status',1)",
+                g.V().property("status", 1).ToString()
+            );
+            Assert.AreEqual(
+                "g.V().property('status',1)",
+                g.V().property("status", 1).ToString()
             );
         }
 

--- a/Icris.GremlinQuery/Icris.GremlinQuery.Tests/QueryTestSet.cs
+++ b/Icris.GremlinQuery/Icris.GremlinQuery.Tests/QueryTestSet.cs
@@ -59,12 +59,12 @@ namespace Icris.GremlinQuery.Tests
                 "g.V().has('status',false)",
                 g.V().has("status", false).ToString()
             );
-            //Test Integer
+            //Test Integer Has
             Assert.AreEqual(
                 "g.V().has('status',1)",
                 g.V().has("status", (int)1).ToString()
             );
-            //Test Double
+            //Test Double Has
             Assert.AreEqual(
                 "g.V().has('status',1.5223)",
                 g.V().has("status", (double)1.5223).ToString()
@@ -81,11 +81,12 @@ namespace Icris.GremlinQuery.Tests
             //Test interger property
             Assert.AreEqual(
                 "g.V().property('status',1)",
-                g.V().property("status", 1).ToString()
+                g.V().property("status", (int)1).ToString()
             );
+            // Test double property
             Assert.AreEqual(
-                "g.V().property('status',1)",
-                g.V().property("status", 1).ToString()
+                "g.V().property('status',1.987)",
+                g.V().property("status", (double)1.987).ToString()
             );
         }
 

--- a/Icris.GremlinQuery/Icris.GremlinQuery/IVertexResult.cs
+++ b/Icris.GremlinQuery/Icris.GremlinQuery/IVertexResult.cs
@@ -28,6 +28,14 @@ namespace Icris.GremlinQuery
         /// </summary>
         IVertexResult has(string name, bool value);
         /// <summary>
+        /// Removes traverser if element does not have given property with value
+        /// </summary>
+        IVertexResult has(string name, int value);
+        /// <summary>
+        /// Removes traverser if element does not have given property with value
+        /// </summary>
+        IVertexResult has(string name, double value);
+        /// <summary>
         /// Removes traverser if element does not satisfy the given comparison
         /// </summary>
         IVertexResult has(string name, Comparer comparer);

--- a/Icris.GremlinQuery/Icris.GremlinQuery/Query.cs
+++ b/Icris.GremlinQuery/Icris.GremlinQuery/Query.cs
@@ -171,6 +171,18 @@ namespace Icris.GremlinQuery
             this.query += $".has('{name}',{value.ToString().ToLower()})";  // gremlin expects a boolean in value lowercase
             return this;
         }
+        IVertexResult IVertexResult.has(string name, int value)
+        {
+            this.query += $".has('{name}',{value})";  // gremlin expects a boolean in value lowercase
+            return this;
+        }
+        IVertexResult IVertexResult.has(string name, double value)
+        {
+            this.query += $".has('{name}',{value.ToString(CultureInfo.InvariantCulture)})";  // gremlin expects a boolean in value lowercase
+            return this;
+        }
+
+
         public IVertexResult has(string name, Comparer comparer)
         {
             this.query += $".has('{name}',{comparer})";


### PR DESCRIPTION
Noticed that support is available in .property but you couldn't compare it with .has. 